### PR TITLE
Support MinSize and MaxSize for resizable extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ PANEL_WIDTH=500
 PANEL_HEIGHT=500
 ```
 
+If you want to build [a resizable extension](https://github.com/Adobe-CEP/CEP-Resources/blob/master/CEP_8.x/Documentation/CEP%208.0%20HTML%20Extension%20Cookbook.md#extension-size), you can use `PANEL_MIN_*` or `PANEL_MAX_*` like this.
+
+```bash
+PANEL_MIN_WIDTH=300
+PANEL_MIN_HEIGHT=300
+PANEL_MAX_WIDTH=800
+PANEL_MAX_HEIGHT=800
+```
+
 ## Communicating with Extendscript
 
 There are few functions that you can import from the `cep-interface` package to ease Extendscript communication from CEP.

--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,10 @@ module.exports = async bundler => {
         iconDarkRollover: config.iconDarkRollover,
         panelWidth: config.panelWidth,
         panelHeight: config.panelHeight,
+        panelMinWidth: config.panelMinWidth,
+        panelMinHeight: config.panelMinHeight,
+        panelMaxWidth: config.panelMaxWidth,
+        panelMaxHeight: config.panelMaxHeight,
         debugInProduction: config.debugInProduction,
         out,
       })

--- a/src/templates/manifest.js
+++ b/src/templates/manifest.js
@@ -7,6 +7,10 @@ module.exports = function({
   cepVersion = '6.0',
   panelWidth = '500',
   panelHeight = '500',
+  panelMinWidth = undefined,
+  panelMinHeight = undefined,
+  panelMaxWidth = undefined,
+  panelMaxHeight = undefined,
   cefParams = [
     '--allow-file-access-from-files',
     '--allow-file-access',
@@ -30,6 +34,16 @@ module.exports = function({
     .filter(({ icon }) => !!icon)
     .map(({ icon, type }) => `<Icon Type="${type}">${icon}</Icon>`)
     .join('\n            ')
+
+  var sizeTemplate = (name, width, height) =>
+    width !== undefined && height !== undefined ? `
+            <${name}>
+              <Width>${width}</Width>
+              <Height>${height}</Height>
+            </${name}>` : '';
+  var size = sizeTemplate('Size', panelWidth, panelHeight);
+  var minSize = sizeTemplate('MinSize', panelMinWidth, panelMinHeight);
+  var maxSize = sizeTemplate('MaxSize', panelMaxWidth, panelMaxHeight);
 
   return `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <ExtensionManifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ExtensionBundleId="${bundleId}" ExtensionBundleName="${bundleName}" ExtensionBundleVersion="${bundleVersion}" Version="${cepVersion}">
@@ -64,11 +78,7 @@ module.exports = function({
         <UI>
           <Type>Panel</Type>
           <Menu>${bundleName}</Menu>
-          <Geometry>
-            <Size>
-              <Width>${panelWidth}</Width>
-              <Height>${panelHeight}</Height>
-            </Size>
+          <Geometry>${size}${minSize}${maxSize}
           </Geometry>
           <Icons>
             ${icons}

--- a/src/utils.js
+++ b/src/utils.js
@@ -69,6 +69,10 @@ function getConfig(package) {
       iconDarkRollover: process.env.ICON_DARK_ROLLOVER,
       panelWidth: process.env.PANEL_WIDTH,
       panelHeight: process.env.PANEL_HEIGHT,
+      panelMinWidth: process.env.PANEL_MIN_WIDTH,
+      panelMinHeight: process.env.PANEL_MIN_HEIGHT,
+      panelMaxWidth: process.env.PANEL_MAX_WIDTH,
+      panelMaxHeight: process.env.PANEL_MAX_HEIGHT,
       debugPorts: debugPortEnvs.length > 0
         ? debugPortEnvs.reduce((obj, key) => {
           obj[key] = parseInt(process.env[key], 10)
@@ -88,6 +92,10 @@ function getConfig(package) {
       iconDarkRollover: package.cep.iconDarkRollover,
       panelWidth: package.cep.panelWidth,
       panelHeight: package.cep.panelHeight,
+      panelMinWidth: package.cep.panelMinWidth,
+      panelMinHeight: package.cep.panelMinHeight,
+      panelMaxWidth: package.cep.panelMaxWidth,
+      panelMaxHeight: package.cep.panelMaxHeight,
       debugPorts: package.cep.debugPorts,
       debugInProduction: package.cep.debugInProduction,
     },
@@ -101,6 +109,10 @@ function getConfig(package) {
       hosts: '*',
       panelWidth: 500,
       panelHeight: 500,
+      panelMinWidth: undefined,
+      panelMinHeight: undefined,
+      panelMaxWidth: undefined,
+      panelMaxHeight: undefined,
       debugInProduction: false,
       debugPorts: {
         PHXS: 3001,
@@ -147,6 +159,10 @@ async function writeExtensionTemplates({
   iconDarkRollover,
   panelWidth,
   panelHeight,
+  panelMinWidth,
+  panelMinHeight,
+  panelMaxWidth,
+  panelMaxHeight,
   debugInProduction,
 }) {
   const manifestContents = manifestTemplate({
@@ -161,6 +177,10 @@ async function writeExtensionTemplates({
     iconDarkRollover,
     panelWidth,
     panelHeight,
+    panelMinWidth,
+    panelMinHeight,
+    panelMaxWidth,
+    panelMaxHeight,
   })
 
   await fs.ensureDir(path.join(out, 'CSXS'))


### PR DESCRIPTION
To resolve issue #8, I add `panelMin*` and `panelMax*` like `panel*` variables.