### PR TITLE
Do not create symlink and enable debug player mode in prod builds

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,6 @@ module.exports = async bundler => {
     })
     bundle()
     async function bundle() {
-      enablePlayerDebugMode()
       const hosts = parseHosts(config.hosts)
       await copyDependencies({ root, out, package })
       await writeExtensionTemplates({
@@ -63,8 +62,12 @@ module.exports = async bundler => {
         debugInProduction: config.debugInProduction,
         out,
       })
-      await symlinkExtension({ bundleId: config.bundleId, out })
       await copyIcons({ bundler, config })
+
+      if (env !== 'production') {
+        enablePlayerDebugMode()
+        await symlinkExtension({ bundleId: config.bundleId, out })
+      }
     }
   }
 }


### PR DESCRIPTION
Enabling the player debug mode and creating a symlink for the extension are both
dev time actions. They also are platform dependent and do not work on a Linux
build server. This PR changes the `bundle()` logic to performs those two
actions only for non-production builds.

A little background:

I have a CI server that 'builds' my extension project whenever I push to the git repo. This CI server is a Linux Docker container. I cannot run `npm run build` (before this PR), because the `parcel-plugin-cep` fails to create the symlink on the CI server (The OS X path of `/Library/Application Support/Adobe/...` obviously is not present on the Linux machine).

I'm aware that I still cannot create a `.zxp` file on the CI server since there is no Linux version of the ZXP packager binary. But this way I get i) confidence that a production build is possible, and ii) a log of build artefacts, so I find it valuable being able to build the extension on CI server.