### PR TITLE
Allow customization of lifecycle section in manifest.xml

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,7 @@ module.exports = async bundler => {
         panelWidth: config.panelWidth,
         panelHeight: config.panelHeight,
         debugInProduction: config.debugInProduction,
+        lifecycle: config.lifecycle,
         out,
       })
       await symlinkExtension({ bundleId: config.bundleId, out })

--- a/src/templates/manifest.js
+++ b/src/templates/manifest.js
@@ -16,6 +16,7 @@ module.exports = function({
   iconRollover,
   iconDarkNormal,
   iconDarkRollover,
+  lifecycle,
 }) {
   var commandLineParams = cefParams.map(
     cefParam => `<Parameter>${cefParam}</Parameter>`
@@ -30,6 +31,11 @@ module.exports = function({
     .filter(({ icon }) => !!icon)
     .map(({ icon, type }) => `<Icon Type="${type}">${icon}</Icon>`)
     .join('\n            ')
+
+  var startOn = (!lifecycle.startOnEvents || lifecycle.startOnEvents.length === 0) ? '' : `
+          <StartOn>
+            ${lifecycle.startOnEvents.map(e => `<Event>${e}</Event>`).join('\n            ')}
+          </StartOn>`;
 
   return `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <ExtensionManifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ExtensionBundleId="${bundleId}" ExtensionBundleName="${bundleName}" ExtensionBundleVersion="${bundleVersion}" Version="${cepVersion}">
@@ -59,7 +65,7 @@ module.exports = function({
           </CEFCommandLine>
         </Resources>
         <Lifecycle>
-          <AutoVisible>true</AutoVisible>
+          <AutoVisible>${lifecycle.autoVisible}</AutoVisible>${startOn}
         </Lifecycle>
         <UI>
           <Type>Panel</Type>

--- a/src/utils.js
+++ b/src/utils.js
@@ -90,6 +90,7 @@ function getConfig(package) {
       panelHeight: package.cep.panelHeight,
       debugPorts: package.cep.debugPorts,
       debugInProduction: package.cep.debugInProduction,
+      lifecycle: package.cep.lifecycle,
     },
     {
       bundleVersion: package.version,
@@ -115,7 +116,8 @@ function getConfig(package) {
         DRWV: 3010,
         MUST: 3011,
         KBRG: 3012,
-      }
+      },
+      lifecycle: {autoVisible: true, startOnEvents: []},
     }
   )
   return config
@@ -148,6 +150,7 @@ async function writeExtensionTemplates({
   panelWidth,
   panelHeight,
   debugInProduction,
+  lifecycle,
 }) {
   const manifestContents = manifestTemplate({
     bundleName,
@@ -161,6 +164,7 @@ async function writeExtensionTemplates({
     iconDarkRollover,
     panelWidth,
     panelHeight,
+    lifecycle,
   })
 
   await fs.ensureDir(path.join(out, 'CSXS'))


### PR DESCRIPTION
We want to set the `AutoVisible` and `StartOn` sections in the CEP
`manifest.xml` for our project. This change allows both to be specified via the
`cep` section in `package.json`. Note: I didn't add support for environment
variable overrides.